### PR TITLE
Fixed typo in link

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,7 +4,7 @@
 ## 1.Install the following dependency library files:
 **The following two libraries are not original branches, they are my modified branches.**
 - [TFT_eSPI](https://github.com/lewisxhe/TFT_eSPI)
-- [Button2](https://github.com/lewisxhe/B·utton2)
+- [Button2](https://github.com/lewisxhe/Button2)
 
 
 


### PR DESCRIPTION
Your update to README.MD '58763c0' on 27 July 2019 broke the "Button2" repo link as it had an extra character in the link. Removed extra character:

Line 7: Changed  B·utton2  to  Button2